### PR TITLE
fix: solved type error TS4023

### DIFF
--- a/src/components/RadioButton/index.ts
+++ b/src/components/RadioButton/index.ts
@@ -1,6 +1,11 @@
 import RadioButtonComponent from './RadioButton'
 import { RadioButtonGroup } from './RadioButtonGroup'
 
-export const RadioButton = Object.assign(RadioButtonComponent, {
+type RadioButtonType = typeof RadioButtonComponent
+type RadioButtonGroup = typeof RadioButtonGroup
+
+interface CombinedTypes extends RadioButtonType, RadioButtonGroup {}
+
+export const RadioButton: CombinedTypes = Object.assign(RadioButtonComponent, {
   Group: RadioButtonGroup,
 })


### PR DESCRIPTION
in this pull request I solved this error   ```error TS4023: Exported variable 'RadioButton' has or is using name 'RadioButtonGroupProps' from external module "/media/maruf/06A432F9A432EB37/react-native-zuhal/src/components/RadioButton/RadioButtonGroup" but cannot be named."```